### PR TITLE
chore: Bump version to 0.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ kotlin.stdlib.default.dependency=false
 android.useAndroidX=true
 
 # Project version (centralized)
-VERSION_NAME=0.1.3
+VERSION_NAME=0.2.0


### PR DESCRIPTION
## Summary

- Bump version from 0.1.3 to 0.2.0

## Details

- Update `VERSION_NAME` in gradle.properties from 0.1.3 to 0.2.0