### PR TITLE
test: Add verification for unused ViewBinding/Paraphrase resource deletion

### DIFF
--- a/scripts/test-prune.sh
+++ b/scripts/test-prune.sh
@@ -57,6 +57,65 @@ else
   exit 1
 fi
 
+# Verify that unused layout (ViewBinding generated but not used) was removed
+if [ -f "example/src/main/res/layout/layout_unused.xml" ]; then
+  echo "FAILURE: layout_unused.xml was not removed (ViewBinding generated but unused)"
+  # Restore resources
+  rm -rf example/src/main/res
+  cp -r "$TEMP_DIR/res_backup" example/src/main/res
+  rm -rf "$TEMP_DIR"
+  exit 1
+else
+  echo "SUCCESS: layout_unused.xml was removed (ViewBinding generated but unused)"
+fi
+
+# Verify that unused Paraphrase string was removed from strings.xml
+if grep -q "unused_paraphrase" "example/src/main/res/values/strings.xml"; then
+  echo "FAILURE: unused_paraphrase was not removed from strings.xml (Paraphrase generated but unused)"
+  # Restore resources
+  rm -rf example/src/main/res
+  cp -r "$TEMP_DIR/res_backup" example/src/main/res
+  rm -rf "$TEMP_DIR"
+  exit 1
+else
+  echo "SUCCESS: unused_paraphrase was removed from strings.xml (Paraphrase generated but unused)"
+fi
+
+# Verify that used ViewBinding layouts are still present
+if [ -f "example/src/main/res/layout/activity_main.xml" ]; then
+  echo "SUCCESS: activity_main.xml was preserved (used via ViewBinding)"
+else
+  echo "FAILURE: activity_main.xml was incorrectly removed"
+  # Restore resources
+  rm -rf example/src/main/res
+  cp -r "$TEMP_DIR/res_backup" example/src/main/res
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+if [ -f "example/src/main/res/layout/item_viewbinding_only.xml" ]; then
+  echo "SUCCESS: item_viewbinding_only.xml was preserved (used via ViewBinding only)"
+else
+  echo "FAILURE: item_viewbinding_only.xml was incorrectly removed"
+  # Restore resources
+  rm -rf example/src/main/res
+  cp -r "$TEMP_DIR/res_backup" example/src/main/res
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+# Verify that used Paraphrase string is still present
+if grep -q "greeting_format" "example/src/main/res/values/strings.xml"; then
+  echo "SUCCESS: greeting_format was preserved (used via Paraphrase)"
+else
+  echo "FAILURE: greeting_format was incorrectly removed"
+  # Restore resources
+  rm -rf example/src/main/res
+  cp -r "$TEMP_DIR/res_backup" example/src/main/res
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
 # Restore resources for future tests
 rm -rf example/src/main/res
 cp -r "$TEMP_DIR/res_backup" example/src/main/res


### PR DESCRIPTION
## Summary
- Add tests to verify that unused ViewBinding/Paraphrase generated resources are correctly pruned

## Details
- Verify `layout_unused.xml` is removed (ViewBinding generated but unused)
- Verify `unused_paraphrase` is removed from strings.xml (Paraphrase generated but unused)
- Verify used ViewBinding layouts are preserved (`activity_main.xml`, `item_viewbinding_only.xml`)
- Verify used Paraphrase string is preserved (`greeting_format`)