### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ kotlin.stdlib.default.dependency=false
 android.useAndroidX=true
 
 # Project version (centralized)
-VERSION_NAME=0.2.0
+VERSION_NAME=0.3.0


### PR DESCRIPTION
## Summary
- Bump version to 0.3.0 for release

## Details
- Update `VERSION_NAME` in `gradle.properties` from 0.2.0 to 0.3.0